### PR TITLE
Fix: more strict regex for python class

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ export class config_defaults {
     ];
     public py = [
         {
-            "pattern": "class (.*?)[(|:]",
+            "pattern": "(?<![^\\r\\n\\t\\f\\v .])class (.*?)[(|:]",
             "clear": ":|(",
             "prefix": "",
             "role": "class",


### PR DESCRIPTION
This fixes false class detection in source if substring 'class' present in some variables.
For example: `tag_class = ' '.join(tag.get('class', ''))`