### PR TITLE
Add option to disable default mapper, add base mapper, support \n in generic_mapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,6 @@
             "type": "object",
             "title": "CodeMap configuration",
             "properties": {
-                "codemap.disableDefaults": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Disable all default mappers."
-                },
                 "codemap.base": {
                     "type": "array",
                     "default": [],

--- a/package.json
+++ b/package.json
@@ -59,6 +59,16 @@
             "type": "object",
             "title": "CodeMap configuration",
             "properties": {
+                "codemap.disableDefaults": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disable all default mappers."
+                },
+                "codemap.base": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Regex-based definition of the mapping rules to always apply."
+                },
                 "codemap.textMode": {
                     "type": "boolean",
                     "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,6 +58,13 @@ function get_map_items(): MapInfo {
             }
 
             let mapper = config.get(value_name, defaults.get(value_name));
+            let baseMapper = config.get('base', defaults.get('base'));
+
+            if (vscode.workspace.getConfiguration('disableDefaults')) {
+                mapper = baseMapper;
+            } else if (mapper != null) {
+                mapper = mapper.concat(baseMapper);
+            }
 
             mapper = get_actual_mapper(mapper);
             if (mapper) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,11 +60,14 @@ function get_map_items(): MapInfo {
             let mapper = config.get(value_name, defaults.get(value_name));
             let baseMapper = config.get('base', defaults.get('base'));
 
-            if (vscode.workspace.getConfiguration('disableDefaults')) {
-                mapper = baseMapper;
-            } else if (mapper != null) {
-                mapper = mapper.concat(baseMapper);
+            if (baseMapper) {
+                if (mapper == null) {
+                    mapper = baseMapper;
+                } else {
+                    mapper = mapper.concat(baseMapper);
+                }
             }
+
 
             mapper = get_actual_mapper(mapper);
             if (mapper) {

--- a/src/mapper_generic.ts
+++ b/src/mapper_generic.ts
@@ -34,10 +34,17 @@ export class mapper {
             let line_num = 0;
             let last_type = '';
             let last_indent = 0;
+            // If there are N newlines in any pattern, need to parse chunks of N+1 lines
+            let allPatterns = mappings.map((m) => m.pattern);
+            let newlineCounts = allPatterns.map((pat) => pat.split('\n').length - 1);
+            let chunkLineCount = newlineCounts.sort()[newlineCounts.length - 1] + 1;
 
-            lines.forEach(line => {
+            for (let line_num = 0; line_num < lines.length; line_num++) {
+                let line = lines
+                    .slice(line_num, line_num + chunkLineCount)
+                    .join('\n');
 
-                line_num = line_num + 1;
+
                 line = line.replace('\t', '    ');
 
                 if (line != '') {
@@ -74,7 +81,7 @@ export class mapper {
                         }
                     }
                 }
-            });
+            };
         } catch (error) {
             members = [];
         }


### PR DESCRIPTION
- Added a base mapper that applies on top of all other mappers
- Added option to disable the default mappers
- Made generic_mapper work with regex containing `\n`

https://github.com/oleg-shilo/codemap.vscode/issues/38
https://github.com/oleg-shilo/codemap.vscode/issues/37