### PR TITLE
Only refresh when the document is saved, not when it is edited

### DIFF
--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -44,7 +44,7 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
         vscode.window.onDidChangeActiveTextEditor(editor => {
             this._onDidChangeTreeData.fire();
         });
-        vscode.workspace.onDidChangeTextDocument(e => {
+        vscode.workspace.onDidSaveTextDocument(e => {
             this._onDidChangeTreeData.fire();
         })
     }


### PR DESCRIPTION
Parsing operates on the saved file, not on the in-memory contents of the editor,
so triggering a refresh whenever the text changed is pointless.

Alternatively, one might wish that parsing should operate on the in-memory text,
which would be easy enough to change, I guess. However, parsing can be expensive
for very long files, so I actually like it that it isn't done too often; VS Code is
already slow enough when tons of extensions are installed.