### PR TITLE
Add default sort direction config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.18.0 (6 November 2022)
+- Issue #72: Add sort button to the CodeMap display
+Added additional configuration for setting a default sorting direction when a new codemap window is opened. The config key for this is "defaultSortDirection" with valid values:
+- ByLocation
+- Asc
+- Desc
+
 ## 1.17.0 (20 October 2022)
 
 - Issue #72: Add sort button to the CodeMap display  

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
                     "default": false,
                     "description": "Enable alphabetical order if the CodeMap a node items."
                 },
+                "codemap.defaultSortDirection": {
+                    "type": "string",
+                    "default": "ByLocation",
+                    "description": "Default direction to sort the codemap tree in new window."
+                },
                 "codemap.textModeExpanded": {
                     "type": "boolean",
                     "default": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "codemap",
     "displayName": "CodeMap",
     "description": "Interactive code map for quick visualization and navigation within code DOM objects (e.g. classes, members).",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "license": "MIT",
     "publisher": "oleg-shilo",
     "engines": {
@@ -73,7 +73,7 @@
                 "codemap.defaultSortDirection": {
                     "type": "string",
                     "default": "ByLocation",
-                    "description": "Default direction to sort the codemap tree in new window."
+                    "description": "Default direction to sort the codemap tree in new window. Allowed values are ByLocation, Asc and Desc."
                 },
                 "codemap.textModeExpanded": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,18 @@
                 "codemap.defaultSortDirection": {
                     "type": "string",
                     "default": "ByLocation",
-                    "description": "Default direction to sort the codemap tree in new window. Allowed values are ByLocation, Asc and Desc."
+                    "enum": [
+                        "ByLocation",
+                        "Asc",
+                        "Desc"
+                    ],
+                    "enumDescriptions": [
+                        "Sorts by location in file",
+                        "Sorts alphabetically ascending ",
+                        "Sorts alphabetically descending"
+                    ],
+                    "markdownDescription": "Default direction to sort the codemap tree in new window.",
+                    "scope": "window"
                 },
                 "codemap.textModeExpanded": {
                     "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -291,7 +291,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     vscode.commands.registerCommand("codemap.sort_location", () => sort(SortDirection.ByLocation));
     vscode.commands.registerCommand("codemap.sort_asc", () => sort(SortDirection.Asc));
-    vscode.commands.registerCommand("codemap.sort_desc", () => sort(SortDirection.Decs));
+    vscode.commands.registerCommand("codemap.sort_desc", () => sort(SortDirection.Desc));
 
     vscode.commands.registerCommand("codemap.mappers", () => {
         let mappers = vscode.workspace.getConfiguration("codemap");

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -42,7 +42,7 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
 
     constructor(private aggregateItems: () => MapInfo) {
         vscode.window.onDidChangeActiveTextEditor(editor => {
-            MapItem.sortDirection = null;
+            MapItem.sortDirection = getDefaultSortDirection();
             this._onDidChangeTreeData.fire();
         });
         vscode.workspace.onDidSaveTextDocument(e => {
@@ -263,6 +263,11 @@ export enum SortDirection {
     Asc
 }
 
+function getDefaultSortDirection() {
+    let dir: string = Config.get('defaultSortDirection').toString();
+    return SortDirection[dir];
+}
+
 export class MapItem extends vscode.TreeItem {
 
     constructor(
@@ -275,7 +280,7 @@ export class MapItem extends vscode.TreeItem {
         super(title, state);
     }
 
-    public static sortDirection: SortDirection;
+    public static sortDirection: SortDirection = getDefaultSortDirection();
 
     public children: MapItem[] = [];
     public sortedByFilePositionChildren: MapItem[] = [];
@@ -320,7 +325,7 @@ export class MapItem extends vscode.TreeItem {
 
     public static compareByTitle(n1: MapItem, n2: MapItem): number {
 
-        if (MapItem.sortDirection == null || MapItem.sortDirection == SortDirection.Asc) {
+        if (MapItem.sortDirection == SortDirection.Asc) {
             return MapItem.compareByTitleAsc(n1, n2);
         }
         else if (MapItem.sortDirection == SortDirection.Decs) {

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -259,7 +259,7 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
 
 export enum SortDirection {
     ByLocation,
-    Decs,
+    Desc,
     Asc
 }
 
@@ -328,7 +328,7 @@ export class MapItem extends vscode.TreeItem {
         if (MapItem.sortDirection == SortDirection.Asc) {
             return MapItem.compareByTitleAsc(n1, n2);
         }
-        else if (MapItem.sortDirection == SortDirection.Decs) {
+        else if (MapItem.sortDirection == SortDirection.Desc) {
             return MapItem.compareByTitleAsc(n2, n1);
         }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,6 +45,7 @@ export class config_defaults {
 
     public textMode = false;
     public sortingEnabled = false;
+    public defaultSortDirection = "ByLocation";
     public textModeExpanded = true;
     public autoReveal = true;
     public textModeLevelPrefix = "   ";
@@ -123,6 +124,7 @@ export class config_defaults {
         else if (name == 'svg') return this.svg;
         else if (name == 'py') return this.py;
         else if (name == 'sortingEnabled') return this.sortingEnabled;
+        else if (name == 'defaultSortDirection') return this.defaultSortDirection;
         else if (name == 'json') return this.json;
         else if (name == 'textModeLevelPrefix') return this.textModeLevelPrefix;
         else if (name == 'textMode') return this.textMode;
@@ -137,7 +139,7 @@ export class Config {
     static defaults = new config_defaults();
 
     public static get(name: string): object {
-        return vscode.workspace.getConfiguration("codemap").get('sortingEnabled', Config.defaults.get('sortingEnabled'));
+        return vscode.workspace.getConfiguration("codemap").get(name, Config.defaults.get(name));
     }
 }
 


### PR DESCRIPTION
Add a default sort direction in extension configuration for sorting the code-map tree in a new window.