### PR TITLE
bug fix: opening new unopened script initially filters all nodes

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,7 +235,7 @@ function reveal_current_line_in_tree(treeView1: vscode.TreeView<MapItem>, treeVi
 
 function sort(direction: SortDirection) {
     MapItem.sortDirection = direction;
-    settingsTreeViewProvider.refresh();
+    settingsTreeViewProvider.refresh();  // triggers both codemap trees refesh
 }
 
 function quick_pick() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -235,7 +235,7 @@ function reveal_current_line_in_tree(treeView1: vscode.TreeView<MapItem>, treeVi
 
 function sort(direction: SortDirection) {
     MapItem.sortDirection = direction;
-    treeViewProvider1.refresh();
+    settingsTreeViewProvider.refresh();
 }
 
 function quick_pick() {

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -46,13 +46,21 @@ export class SettingsTreeProvider implements vscode.TreeDataProvider<SettingsIte
     }
 
     public nodeTypesAllowedByUser(filename: string): string[] {
-        let nodeTypesAllowed: string[] = [];
-        for (let key in this._settings[filename]) {
-            if (this._settings[filename][key]) {
-                nodeTypesAllowed.push(key);
+        if (this._settings[filename] != undefined) {
+            let nodeTypesAllowed: string[] = [];
+            for (let key in this._settings[filename]) {
+                if (this._settings[filename][key]) {
+                    nodeTypesAllowed.push(key);
+                }
             }
+            return nodeTypesAllowed;
         }
-        return nodeTypesAllowed;
+        else {
+            this.getSettingItems();
+            // manually trigger settngs tree update for file
+            return this.nodeTypesAllowedByUser(filename);
+        }
+
     }
 
     public allow_all(filename: string) {
@@ -80,6 +88,10 @@ export class SettingsTreeProvider implements vscode.TreeDataProvider<SettingsIte
     public getSettingItems(): SettingsItem[] {
         let codeMapTree = this.aggregateItems();
         const filename: string = codeMapTree.sourceFile;
+
+        if (filename == null) {
+            return [];
+        }
 
         let codeMapTypes: Set<string> = new Set<string>();
         codeMapTree['items'].filter((strItem) => strItem != '').forEach(

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -57,7 +57,7 @@ export class SettingsTreeProvider implements vscode.TreeDataProvider<SettingsIte
         }
         else {
             this.getSettingItems();
-            // manually trigger settngs tree update for file
+            // manually trigger settings tree update for file
             return this.nodeTypesAllowedByUser(filename);
         }
 


### PR DESCRIPTION
Settings functionality accidently added in a bug that sometimes occurs when first opening a new file in the vscode session and using the mapper. The refresh of the code-map tree sometimes occurs before the settings-tree.

The code-map tree provider calls a method of the settings tree provider to get the "valid node types" of the code-map tree. In this case the settings tree didn't know what nodes of the code-map are valid as it wasn't refreshed. So it returns no nodes to the code-map tree provider, and all nodes are filtered out leaving a blank map. The settings tree then is refreshed so we have a valid settings window but no map. See below:

![image](https://user-images.githubusercontent.com/53578447/205497180-a8b263be-5cdd-4920-a592-f158bc98d802.png)

If you refresh the tree by saving or altering the window the issue resolves itself.

As a fix I've forced the settings tree provider to manually refresh the settings information when it's called by the code-map tree provider.