### PR TITLE
Improving Generic Map by Reworking levelIndent

### DIFF
--- a/src/mapper_generic.ts
+++ b/src/mapper_generic.ts
@@ -42,7 +42,6 @@ export class mapper {
     public static generate(file: string, mappings: SyntaxMapping[]): string[] {
 
         // # Parse
-        let item_max_length = 0;
         let members = [];
 
         try {
@@ -55,8 +54,6 @@ export class mapper {
             lines = text.split(/\r?\n/g);
 
             let line_num = 0;
-            let last_type = '';
-            let last_indent = 0;
 
             lines.forEach(line => {
 
@@ -66,15 +63,13 @@ export class mapper {
                 if (line != '') {
 
                     let code_line = line.trimStart();
+                    let level_indent = line.length - code_line.length;
 
                     for (let item of mappings) {
 
                         let m = line.match(item.regex);
 
                         if (m) {
-
-                            let level_indent = line.length - code_line.length;
-
                             let level_hierarchy = 0
                             if (item.levelIndent)
                                 level_hierarchy = item.levelIndent;
@@ -87,7 +82,6 @@ export class mapper {
                                     .forEach(text => {
                                         try {
                                             // match = match.replaceAll(text, ''); // fails to treat arguments as regex :o(
-// vscode.workspace.getConfiguration vscode.window.activeTextEditor.options.tabSize
                                             match = match.replace(new RegExp(text, 'g'), '');
                                         }
                                         catch (error) {
@@ -99,8 +93,16 @@ export class mapper {
                                 match += item.suffix;
                             if (item.prefix)
                                 match = item.prefix + match;
-
+                            // TODO: We should do the processing here instead.
+                            // Collecting and processing may lead to
+                            // misinterpretation of hierarch, hence
+                            // when we go out of a function and enter
+                            // another indentation and have a mapping,
+                            // this mapping will be nested under functions
+                            // even it is not inside the function
+                            //
                             members.push([line_num, item.role, match, level_indent, item.icon, level_hierarchy]);
+
                             break;
                         }
                     }

--- a/src/mapper_generic.ts
+++ b/src/mapper_generic.ts
@@ -74,8 +74,10 @@ export class mapper {
                         if (m) {
 
                             let level_indent = line.length - code_line.length;
+
+                            let level_hierarchy = 0
                             if (item.levelIndent)
-                                level_indent = item.levelIndent;
+                                level_hierarchy = item.levelIndent;
 
                             let match = m[0];
 
@@ -84,8 +86,8 @@ export class mapper {
                                     .split('|')
                                     .forEach(text => {
                                         try {
-                                            // match = match.replaceAll(text, ''); // fails to treat arguments as regex :o( 
-
+                                            // match = match.replaceAll(text, ''); // fails to treat arguments as regex :o(
+// vscode.workspace.getConfiguration vscode.window.activeTextEditor.options.tabSize
                                             match = match.replace(new RegExp(text, 'g'), '');
                                         }
                                         catch (error) {
@@ -98,7 +100,7 @@ export class mapper {
                             if (item.prefix)
                                 match = item.prefix + match;
 
-                            members.push([line_num, item.role, match, level_indent, item.icon]);
+                            members.push([line_num, item.role, match, level_indent, item.icon, level_hierarchy]);
                             break;
                         }
                     }
@@ -120,6 +122,7 @@ export class mapper {
                 let content = item[2];
                 let indent = item[3];
                 let icon = item[4];
+                let hierarchy = item[5];
                 let extra_line = '';
 
                 if (indent == last_indent && content_type != last_type)
@@ -128,7 +131,8 @@ export class mapper {
                 let prefix = ' '.repeat(indent);
                 let lean_content = content.trimStart();
 
-                map = map + extra_line + prefix + lean_content + '|' + String(line) + '|' + icon + '\n';
+                map = map + extra_line + prefix + lean_content + '|' +
+                    String(line) + '|' + icon + '|'+ String(hierarchy) + '\n';
 
                 last_indent = indent;
                 last_type = content_type;

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -252,12 +252,11 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
         let level_hierarchy = node.level_hierarchy;
 
         if (!(map_hierarchy.length)) {
-            if (level_hierarchy == 0)
+            nodes.push(node)
+
+            if (level_hierarchy)
             {
-                nodes.push(node);
-            }
-            else
-            {
+                node = nodes[nodes.length - 1]
                 map_hierarchy.push(node)
             }
         }
@@ -271,11 +270,10 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
                 {
                     map_hierarchy.push(node);
                 }
-                else
-                {
-                    parent.addChildItem(node);
-                    node.parent = parent;
-                }
+
+                parent.addChildItem(node);
+                node.parent = parent;
+
             }
             else if (level_indent == parent.level_indent)
             {
@@ -284,19 +282,33 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
                     if  (level_hierarchy < parent.level_hierarchy)
                     {
                         map_hierarchy.pop()
-                        FavoritesTreeProvider.process_node(node, nodes, map_hierarchy)
+                        FavoritesTreeProvider.process_node(
+                            node,
+                            nodes,
+                            map_hierarchy
+                        )
                     }
                     else if (level_hierarchy == parent.level_hierarchy)
                     {
-                        nodes.push(parent)
+                        if (parent.parent) {
+                            parent.parent.addChildItem(node)
+                            node.parent = parent.parent
+                        }
+                        else {
+                            nodes.push(node)
+                        }
+
                         map_hierarchy.pop()
                     }
-                    else // TODO Implementing outline type, that different types will not
-                    {    // TODO race hierarchy (nestable will not nest the other type on same
-                         // TODO indent level)
+                    else
+                    {
+                        // TODO Implementing outline type, that different types
+                        // TODO will not race hierarchy (nestable will not nest
+                        // TODO the other type on same indent level)
                         parent.addChildItem(node);
                         node.parent = parent;
                     }
+
                     map_hierarchy.push(node)
                 }
                 else
@@ -308,15 +320,8 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
             else if (level_indent < parent.level_indent)
             {
                 map_hierarchy.pop()
-                // parent = map_hierarchy[map_hierarchy.length - 1]
                 FavoritesTreeProvider.process_node(node, nodes, map_hierarchy)
-                // if (level_hierarchy)
-                // {
-                //     map_hierarchy.push(node)
-                // }
-                // else
-                // {
-                //     nodes.push(node)
+
             }
         }
     }
@@ -337,10 +342,15 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
         // Intelligently taking tab size (in terms of number of spaces) from active text editor
         let levelUnit : number;
         let levelUnit_t = vscode.window.activeTextEditor.options.tabSize;
+
+        // Language
+        let editor_language = vscode.window.activeTextEditor.document.languageId;
+
         if (typeof levelUnit_t === "string")
         {
-            // set indentation according to language or scrape it from document
-            let editor_language = vscode.window.activeTextEditor.document.languageId
+            // TODO Set indentation according to language or
+            // TODO scrape it from document
+            editor_language;
 
             levelUnit = 4;
         }
@@ -425,6 +435,7 @@ export class FavoritesTreeProvider implements vscode.TreeDataProvider<MapItem> {
                             nodes,
                             map_hierarchy
                         )
+
                         // if (level_indent == 0) {
                         //     nodes.push(node);
                         // }


### PR DESCRIPTION
# Description
Implementing hierarchy level by promoting 
levelIndent to identify not a whitespace 
indent on files, but a hierarchy level among 
other mapping rules of a indent dependant
programming language file.

### Non-hiearachy Mapping Rules
- If a mapping rule has no hiearchy, it cannot 
nest other mapping rules.

### Hierarchy Priority
- Mapping rules with levelIndent property set 
other than zero (0) can nest lower level
hierarchies (lower number, higher hierarchy).

### Resolving Hierarchy with same Indentation
- When mapping rules with levelIndent has same 
indentation, higher hierarchy mapping rule will
nest lower level hierarchy.
_____________________
## TODO
- Implementing mapping rule category: When 
different categorie mapping rules with same
indentation but different hierarchy levels can
nest each other.
- Supporting non-indent based programming 
languages by improving hierarchy algorithm.