### PR TITLE
Add "name" parameter to generic mappers so it shows in the "Codemap Settings" Tree View

### DIFF
--- a/src/mapper_generic.ts
+++ b/src/mapper_generic.ts
@@ -13,6 +13,7 @@ export interface SyntaxMapping {
     levelIndent: number;
     role: string;
     icon: string;
+    name: string;
 }
 
 export class mapper {
@@ -98,7 +99,10 @@ export class mapper {
                             if (item.prefix)
                                 match = item.prefix + match;
 
-                            members.push([line_num, item.role, match, level_indent, item.icon]);
+                            if (! item.name)
+                                item.name = item.icon
+
+                            members.push([line_num, item.role, match, level_indent, item.icon, item.name]);
                             break;
                         }
                     }
@@ -120,6 +124,7 @@ export class mapper {
                 let content = item[2];
                 let indent = item[3];
                 let icon = item[4];
+                let type_name = item[5];
                 let extra_line = '';
 
                 if (indent == last_indent && content_type != last_type)
@@ -128,7 +133,7 @@ export class mapper {
                 let prefix = ' '.repeat(indent);
                 let lean_content = content.trimStart();
 
-                map = map + extra_line + prefix + lean_content + '|' + String(line) + '|' + icon + '\n';
+                map = map + extra_line + prefix + lean_content + '|' + String(line) + '|' + icon + '|' + type_name + '\n';
 
                 last_indent = indent;
                 last_type = content_type;

--- a/src/tree_view.ts
+++ b/src/tree_view.ts
@@ -102,7 +102,14 @@ export class SettingsTreeProvider implements vscode.TreeDataProvider<SettingsIte
 
         let codeMapTypes: Set<string> = new Set<string>();
         codeMapTree['items'].filter((strItem) => strItem != '').forEach(
-            (x) => { codeMapTypes.add(x.trimStart().split("|")[2]); }
+            (x) => {
+                let type_args = x.trimStart().split("|")
+                let name = type_args[2]
+                if (type_args.length > 3)
+                    name = type_args[3]
+
+                codeMapTypes.add(name)
+            }
         );
 
         let ArrCodeMapTypes = Array.from(codeMapTypes);
@@ -301,6 +308,7 @@ export class DocumentTreeProvider implements vscode.TreeDataProvider<MapItem> {
                 let tokens = item.split('|');
                 let lineNumber = 0;
                 let icon = 'document';
+                let name = icon;
 
                 let title: string = item;
 
@@ -317,8 +325,12 @@ export class DocumentTreeProvider implements vscode.TreeDataProvider<MapItem> {
                         title = tokens[0];
                         lineNumber = Number(tokens[1]) - 1;
                         icon = tokens[2];
+                        name = icon;
+                        if (tokens.length > 3)
+                            name = tokens[3]
                     } catch (error) {
                     }
+
                 }
                 else
                     source_file = null;
@@ -357,7 +369,7 @@ export class DocumentTreeProvider implements vscode.TreeDataProvider<MapItem> {
                     lineNumber
                 );
 
-                if (nodeTypesToKeep.includes(icon)) {
+                if (nodeTypesToKeep.includes(name)) {
                     if (plainTextMode) {
                         node.collapsibleState = vscode.TreeItemCollapsibleState.None;
                         node.label = non_whitespace_empty_char.repeat(nesting_level) + title;


### PR DESCRIPTION
First of all thank you so much for creating this extension, I started using it a couple of months ago and it has been incredibly useful.

I recently started using it to mark "TODO" docstrings in the code. So I made a new pattern and set a custom icon and realized the name of the icon also appears in the "Codemap Settings" Tree View.

<img width="429" height="607" alt="image" src="https://github.com/user-attachments/assets/f9057277-46b4-49a4-92f5-b5935986cafb" />

So this PR implements a new optional parameter called "name" you can add to your generic mappers so it displays there.

<img width="716" height="179" alt="image" src="https://github.com/user-attachments/assets/84a53250-0068-460d-b8e9-699f052b3d59" />

<img width="429" height="611" alt="image" src="https://github.com/user-attachments/assets/f4a84643-fb86-498d-9398-2f5b61ece23f" />

I know my use-case is very specific, but I think this feature can help a lot when creating new mappers without modifying the extension. 

Have a nice day!
